### PR TITLE
Add python support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 node_modules
 .bundle/*
 .DS_Store
-# ignore python virtual environment
-python/env/*
-python/__pycache__/*
-python/.pytest_cache/*
-*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 python/env/*
 python/__pycache__/*
 python/.pytest_cache/*
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .DS_Store
 # ignore python virtual environment
 python/env/*
+python/__pycache__/*
+python/.pytest_cache/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .bundle/*
 .DS_Store
+# ignore python virtual environment
+python/env/*

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,5 @@
+# ignore python virtual environment
+env/*
+__pycache__/*
+.pytest_cache/*
+*.pyc

--- a/python/README.md
+++ b/python/README.md
@@ -44,6 +44,23 @@ pip install -r requirements.txt
 
 This will also install numpy and scipy for your convenience. However, you are not required to use these packages to complete the exercise.
 
+
+### Creating the solution
+
+You should see the file `safe_spaces.py`, which contains a class definition for a class named `SafetyFinder`. This class contains a method called `find_safe_spaces` which takes a single argument, `agents`.
+
+We are expecting `agents` to be a list of coordinates, e.g.
+
+```python
+finder = SafetyFinder()
+finder.find_safe_spaces(['A1', 'B2', 'C3'])
+```
+
+should return a list of the safest spaces in the city for Alex to hide.
+
+The tests expect that you will use this method; however, you may add other methods to the class as necessary for your solution.
+
+
 ### Running tests
 
 To run the test:

--- a/python/README.md
+++ b/python/README.md
@@ -1,15 +1,53 @@
-# Find save places in Ruby
+# Find safe places in Python
 
-Requirements:
+### Requirements
 
-rspec
+For this exercise we will be using python3.
+
+You can [install requirements manually](#manual-installation), or if you are comfortable using [virtual environments](#virtualenv-installation), a `requirements.txt` file has been provided for your convenience.
+
+#### Manual Installation
+
+To get started manually, install the following packages:
+
+pytest
 
 ```
-gem install rspec
+pip3 install pytest
 ```
+
+#### virtualenv Installation
+
+If you do not have virtualenv installed, first install it by running:
+
+```
+pip3 install virtualenv
+```
+
+Next, create a virtual environment by typing:
+
+```
+python3 -m venv env
+```
+
+Then, activate the virtual environment as follows:
+
+```
+source env/bin/activate
+```
+
+Finally, you can install the requirements from `requirements.txt` as follows:
+
+```
+pip install -r requirements.txt
+```
+
+This will also install numpy and scipy for your convenience. However, you are not required to use these packages to complete the exercise.
+
+### Running tests
 
 To run the test:
 
 ```
-rspec run.rb
+pytest safe_spaces_test.py
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,15 @@
+# Find save places in Ruby
+
+Requirements:
+
+rspec
+
+```
+gem install rspec
+```
+
+To run the test:
+
+```
+rspec run.rb
+```

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,9 @@
+atomicwrites==1.1.5
+attrs==18.1.0
+more-itertools==4.3.0
+numpy==1.15.0
+pluggy==0.7.1
+py==1.5.4
+pytest==3.7.1
+scipy==1.1.0
+six==1.11.0

--- a/python/safe_spaces.py
+++ b/python/safe_spaces.py
@@ -1,5 +1,30 @@
+"""Solve the spy game!"""
+
 class SafetyFinder:
-    
+    """A class that contains everything we need to find the
+    safest places in the city for Alex to hide out
+    """
+
+    def convert_coordinates(self, coordinates):
+        """This method should take a list of alphanumeric coordinates (e.g. 'A6')
+        and return an array of the coordinates converted to arrays with zero-indexing.
+        For instance, 'A6' should become [0, 5]
+
+        Arguments:
+        coordinates -- a list-like object containing alphanumeric coordinates.
+
+        Returns a list of coordinates in zero-indexed vector form.
+        """
+        pass
 
     def find_safe_spaces(self, agents):
+        """This method will take an array with agent locations and find
+        the safest places in the city for Alex to hang out.
+
+        Arguments:
+        agents -- a list-like object containing the map coordinates of agents.
+            Each entry should be formatted in alphanumeric form, e.g. A8, C10, etc.
+
+        Returns a list of safe spaces in letter-number form.
+        """
         pass

--- a/python/safe_spaces.py
+++ b/python/safe_spaces.py
@@ -1,0 +1,5 @@
+class SafetyFinder:
+    
+
+    def find_safe_spaces(self, agents):
+        pass

--- a/python/safe_spaces_test.py
+++ b/python/safe_spaces_test.py
@@ -1,0 +1,42 @@
+import unittest
+
+from safe_spaces import SafetyFinder
+
+class SafetyFinderTest(unittest.TestCase):
+    def test_no_agents(self):
+        self.assertEqual(SafetyFinder().find_safe_spaces([]),
+                         'The whole city is safe for Alex! :-)')
+    
+    def test_agents_everywhere(self):
+        agents = ['A1','A2','A3','A4','A5','A6','A7','A8','A9','A10',
+                  'B1','B2','B3','B4','B5','B6','B7','B8','B9','B10',
+                  'C1','C2','C3','C4','C5','C6','C7','C8','C9','C10',
+                  'D1','D2','D3','D4','D5','D6','D7','D8','D9','D10',
+                  'E1','E2','E3','E4','E5','E6','E7','E8','E9','E10',
+                  'F1','F2','F3','F4','F5','F6','F7','F8','F9','F10',
+                  'G1','G2','G3','G4','G5','G6','G7','G8','G9','G10',
+                  'H1','H2','H3','H4','H5','H6','H7','H8','H9','H10',
+                  'I1','I2','I3','I4','I5','I6','I7','I8','I9','I10',
+                  'J1','J2','J3','J4','J5','J6','J7','J8','J9','J10']
+        self.assertEqual(SafetyFinder().find_safe_spaces(agents),
+                         'There are no safe locations for Alex! :-(')
+
+    def test_round1(self):
+        agents = ['B2','D6','E9','H4','H9','J2']
+        self.assertEqual(sorted(SafetyFinder().find_safe_spaces(agents)),
+                         sorted(['A10','A8','F1']))
+
+    def test_round2(self):
+        agents = ['B4','C4','C8','E2','F10','H1','J6']
+        self.assertEqual(sorted(SafetyFinder().find_safe_spaces(agents)),
+                         sorted(['A1', 'A10', 'E6', 'F5', 'F6', 'G4', 'G5',
+                                 'G7','H8','I9', 'J10']))
+
+    def test_round3(self):
+        agents = ['A1']
+        self.assertEqual(sorted(SafetyFinder().find_safe_spaces(agents)),
+                         sorted(['J10']))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/safe_spaces_test.py
+++ b/python/safe_spaces_test.py
@@ -3,8 +3,16 @@ import unittest
 
 from safe_spaces import SafetyFinder
 
+@unittest.skip("Comment or delete this line to solve the challenge with python")
 class SafetyFinderTest(unittest.TestCase):
     """A class that contains the unit tests that adhere to the game spec"""
+
+    def test_convert_coordinates(self):
+        """Test for accurate conversion from alphanumeric coordinates
+        to indexed vector coordinates.
+        """
+        self.assertEqual(SafetyFinder().convert_coordinates(['A5']),
+                         [[0, 5]])
 
     def test_no_agents(self):
         """Tests for no agents in the city"""

--- a/python/safe_spaces_test.py
+++ b/python/safe_spaces_test.py
@@ -1,38 +1,46 @@
+"""Run unittests for the ThoughtWorks spy game"""
 import unittest
 
 from safe_spaces import SafetyFinder
 
 class SafetyFinderTest(unittest.TestCase):
+    """A class that contains the unit tests that adhere to the game spec"""
+
     def test_no_agents(self):
+        """Tests for no agents in the city"""
         self.assertEqual(SafetyFinder().find_safe_spaces([]),
                          'The whole city is safe for Alex! :-)')
-    
+
     def test_agents_everywhere(self):
-        agents = ['A1','A2','A3','A4','A5','A6','A7','A8','A9','A10',
-                  'B1','B2','B3','B4','B5','B6','B7','B8','B9','B10',
-                  'C1','C2','C3','C4','C5','C6','C7','C8','C9','C10',
-                  'D1','D2','D3','D4','D5','D6','D7','D8','D9','D10',
-                  'E1','E2','E3','E4','E5','E6','E7','E8','E9','E10',
-                  'F1','F2','F3','F4','F5','F6','F7','F8','F9','F10',
-                  'G1','G2','G3','G4','G5','G6','G7','G8','G9','G10',
-                  'H1','H2','H3','H4','H5','H6','H7','H8','H9','H10',
-                  'I1','I2','I3','I4','I5','I6','I7','I8','I9','I10',
-                  'J1','J2','J3','J4','J5','J6','J7','J8','J9','J10']
+        """Tests for agents everywhere in the city. Oh no!!"""
+        agents = ['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10',
+                  'B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10',
+                  'C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9', 'C10',
+                  'D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'D8', 'D9', 'D10',
+                  'E1', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9', 'E10',
+                  'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10',
+                  'G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'G8', 'G9', 'G10',
+                  'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'H7', 'H8', 'H9', 'H10',
+                  'I1', 'I2', 'I3', 'I4', 'I5', 'I6', 'I7', 'I8', 'I9', 'I10',
+                  'J1', 'J2', 'J3', 'J4', 'J5', 'J6', 'J7', 'J8', 'J9', 'J10']
         self.assertEqual(SafetyFinder().find_safe_spaces(agents),
                          'There are no safe locations for Alex! :-(')
 
     def test_round1(self):
-        agents = ['B2','D6','E9','H4','H9','J2']
+        """Test for six agents at specified locations"""
+        agents = ['B2', 'D6', 'E9', 'H4', 'H9', 'J2']
         self.assertEqual(sorted(SafetyFinder().find_safe_spaces(agents)),
-                         sorted(['A10','A8','F1']))
+                         sorted(['A10', 'A8', 'F1']))
 
     def test_round2(self):
-        agents = ['B4','C4','C8','E2','F10','H1','J6']
+        """Test for seven agents at specified locations"""
+        agents = ['B4', 'C4', 'C8', 'E2', 'F10', 'H1', 'J6']
         self.assertEqual(sorted(SafetyFinder().find_safe_spaces(agents)),
                          sorted(['A1', 'A10', 'E6', 'F5', 'F6', 'G4', 'G5',
-                                 'G7','H8','I9', 'J10']))
+                                 'G7', 'H8', 'I9', 'J10']))
 
     def test_round3(self):
+        """Test when only a single agent remains in the city"""
         agents = ['A1']
         self.assertEqual(sorted(SafetyFinder().find_safe_spaces(agents)),
                          sorted(['J10']))


### PR DESCRIPTION
This adds support for python in the following way:

- adds a python folder with a README with language-specific setup instructions
- adds a unit test file that specifies a number of tests, using the ruby example as the source of truth
- adds a class definition file in which the user is intended to craft their solution
- adds a `requirements.txt` file that should standardize the package situation

Ongoing work:

- The tests for converting alphanumeric coordinates to vector coordinates is not yet complete, as the Ruby tests have no source of truth at the time of this submission.
- The README needs some cleaning up