### PR TITLE
Fix javascript tests

### DIFF
--- a/javascript/test/savePlaces.test.js
+++ b/javascript/test/savePlaces.test.js
@@ -32,7 +32,7 @@ xdescribe('Spy Places Level 2 - find save places', () => {
   it('some places are save if agents are some', () => {
     const agents = [[0, 0], [0, 9], [1, 5], [5, 1], [9, 0], [9, 9]]
     expect(findSafePlaces(agents).length).toEqual(3)
-    expect(findSafePlaces(agents)).toEqual(expect.arrayContaining([5, 7], [6, 6], [7, 5]))
+    expect(findSafePlaces(agents)).toEqual(expect.arrayContaining([[5, 7], [6, 6], [7, 5]]))
   })
   it('one place is save', () => {
     const agents = [[0, 0]]
@@ -84,7 +84,6 @@ xdescribe('Spy Places Level 3 - find edge cases and give advice to Alex', () => 
   })
   it('agent outside the city', () => {
     const agents = ['A12']
-    expect(adviceForAlex(agents).length).toEqual(1)
     expect(adviceForAlex(agents)).toEqual('The whole city is safe for Alex! :-)')
   })
 })

--- a/javascript/test/savePlaces.test.js
+++ b/javascript/test/savePlaces.test.js
@@ -64,27 +64,27 @@ xdescribe('Spy Places Level 3 - find edge cases and give advice to Alex', () => 
 
   it('some places are save if agents are some', () => {
     const agents = ['B2', 'D6', 'E9', 'H4', 'H9', 'J2']
-    expect(convertCoordinates(agents).length).toEqual(3)
-    expect(convertCoordinates(agents)).toEqual(expect.arrayContaining(['A10', 'A8', 'F1']))
+    expect(adviceForAlex(agents).length).toEqual(3)
+    expect(adviceForAlex(agents)).toEqual(expect.arrayContaining(['A10', 'A8', 'F1']))
   })
   it('some places are save if agents are some', () => {
     const agents = ['B4', 'C4', 'C8', 'E2', 'F10', 'H1', 'J6']
-    expect(convertCoordinates(agents).length).toEqual(11)
-    expect(convertCoordinates(agents)).toEqual(expect.arrayContaining(['A1', 'A10', 'E6', 'F5', 'F6', 'G4', 'G5', 'G7', 'H8', 'I9', 'J10']))
+    expect(adviceForAlex(agents).length).toEqual(11)
+    expect(adviceForAlex(agents)).toEqual(expect.arrayContaining(['A1', 'A10', 'E6', 'F5', 'F6', 'G4', 'G5', 'G7', 'H8', 'I9', 'J10']))
   })
   it('some places are save if agents are some', () => {
     const agents = ['A1', 'A10', 'B6', 'F2', 'J1', 'J10']
-    expect(convertCoordinates(agents).length).toEqual(3)
-    expect(convertCoordinates(agents)).toEqual(expect.arrayContaining(['F8', 'G7', 'H6']))
+    expect(adviceForAlex(agents).length).toEqual(3)
+    expect(adviceForAlex(agents)).toEqual(expect.arrayContaining(['F8', 'G7', 'H6']))
   })
   it('one save place', () => {
     const agents = ['A1']
-    expect(convertCoordinates(agents).length).toEqual(1)
-    expect(convertCoordinates(agents)).toEqual(expect.arrayContaining(['J10']))
+    expect(adviceForAlex(agents).length).toEqual(1)
+    expect(adviceForAlex(agents)).toEqual(expect.arrayContaining(['J10']))
   })
   it('agent outside the city', () => {
     const agents = ['A12']
-    expect(convertCoordinates(agents).length).toEqual(1)
-    expect(convertCoordinates(agents)).toEqual('The whole city is safe for Alex! :-)')
+    expect(adviceForAlex(agents).length).toEqual(1)
+    expect(adviceForAlex(agents)).toEqual('The whole city is safe for Alex! :-)')
   })
 })


### PR DESCRIPTION
I think we have some copy/paste errors here:
* Level 3 tests should test the _adviceForAlex_ method instead of the _convertCoordinates_ method.
* The last level 3 test expects a string instead of an array. The string doesn't have a length of 1 but of the amount of characters in it. Since the amount of places is not relevant in this scenario I removed the test for length.
* One level 2 test is missing the outer square brackets of the expected array.